### PR TITLE
Refactor metadata extraction to support Dependencies, Cache and `.tgz` files 

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Download and Start Pocketbase v0.25.9 in `./apps/backend`:
 ./apps/backend/pocketbase.exe serve
 ```
 
+> [!TIP]
+> Use `--dev` flag to debug SQL statements and 400 errors
+
 Start the server
 
 ```bash

--- a/apps/api/src/mods/utils/db/versionMetadataRepo.ts
+++ b/apps/api/src/mods/utils/db/versionMetadataRepo.ts
@@ -1,0 +1,13 @@
+import { ModVersionsMetadataRecord } from '@civmods/parser';
+import { pb } from '../../../core/pocketbase';
+
+export async function findModVersionMetadata(
+  versionId: string
+): Promise<ModVersionsMetadataRecord | null> {
+  const res = await pb.collection('mod_versions_metadata').getList(1, 1, {
+    filter: pb.filter(`version_id = {:version_id}`, {
+      version_id: versionId,
+    }),
+  });
+  return res?.items?.[0] ?? null;
+}

--- a/apps/api/src/mods/utils/download/downloadVersionFile.ts
+++ b/apps/api/src/mods/utils/download/downloadVersionFile.ts
@@ -1,0 +1,139 @@
+import { parseContentDisposition } from '@civmods/parser';
+import { pb } from '../../../core/pocketbase';
+import { DownloadError } from '../errors';
+import fs from 'fs/promises';
+import { findModVersionMetadata } from '../db/versionMetadataRepo';
+import path from 'path';
+import { ARCHIVE_DIR } from '../fs/extractionDirs';
+
+/**
+ * Converts a Google Drive file URL into a direct download link.
+ * @param url - The original Google Drive file URL
+ * @returns Direct download URL or null if invalid
+ */
+function getGoogleDriveDirectDownloadUrl(url: string): string | null {
+  const match = url.match(/drive\.google\.com\/file\/d\/([^/]+)/);
+  if (match && match[1]) {
+    return `https://drive.google.com/uc?export=download&id=${match[1]}`;
+  }
+  return null;
+}
+
+/**
+ * Generic fetch wrapper with User-Agent
+ */
+async function fetchFile(url: string): Promise<Response> {
+  const res = await fetch(url, {
+    headers: { 'User-Agent': 'CivMods/1.0' },
+  });
+  if (!res.ok) throw new Error(`Failed to download ${url}`);
+  return res;
+}
+
+/**
+ * Try to fetch the file from the cached PocketBase URL
+ */
+async function tryDownloadFromCachedUrl(id: string): Promise<Response | null> {
+  const versionMetadata = await findModVersionMetadata(id);
+  if (!versionMetadata?.archive_file) return null;
+
+  const cachedUrl = pb.files.getURL(
+    versionMetadata,
+    versionMetadata.archive_file,
+    {
+      token: await pb.files.getToken(),
+    }
+  );
+
+  console.log(`Trying cached download URL: ${cachedUrl}`);
+
+  try {
+    const res = await fetchFile(cachedUrl);
+    console.log(`Downloaded from cache: ${cachedUrl}`);
+    return res;
+  } catch (err) {
+    console.warn(`Cached download failed: ${cachedUrl}`, err);
+    return null;
+  }
+}
+
+/**
+ * If the file is redirected externally, handle special logic (e.g., Google Drive)
+ */
+async function handleExternalRedirects(
+  res: Response,
+  id: string
+): Promise<Response> {
+  if (res.redirected) {
+    await pb.collection('mod_versions').update(id, {
+      is_external_download: true,
+    });
+
+    if (res.url.includes('//drive.google.com/')) {
+      const updatedUrl = getGoogleDriveDirectDownloadUrl(res.url);
+      if (!updatedUrl) {
+        console.warn(`Failed to get direct download link for ${res.url}`);
+        throw new Error(`Google Drive redirect failed: ${res.url}`);
+      }
+      return await fetchFile(updatedUrl);
+    }
+  }
+  return res;
+}
+
+/**
+ * Save the downloaded file and return the path
+ */
+async function saveDownloadedFile(
+  res: Response,
+  id: string
+): Promise<[string, string]> {
+  const buffer = await res.arrayBuffer();
+  const { filename, extension } = parseContentDisposition(
+    res.headers.get('content-disposition')
+  );
+
+  if (!extension) {
+    throw new DownloadError(
+      `No extension found. Filename: ${filename}, Content-Disposition: ${res.headers.get(
+        'content-disposition'
+      )}`
+    );
+  }
+
+  const archivePath = path.join(ARCHIVE_DIR, `${id}.${extension}`);
+  await fs.writeFile(archivePath, Buffer.from(buffer));
+  return [filename!, archivePath];
+}
+
+/**
+ * Download a mod version file, attempting cache first, with fallback.
+ * @param versionDownloadUrl - The primary URL for the file.
+ * @param id - The mod version ID.
+ */
+export async function downloadVersionFile(
+  versionDownloadUrl: string,
+  id: string
+): Promise<{ isCached: boolean; filename: string; archivePath: string }> {
+  let res = await tryDownloadFromCachedUrl(id);
+
+  if (res) {
+    const [filename, archivePath] = await saveDownloadedFile(res, id);
+    return { isCached: true, filename, archivePath };
+  }
+
+  // Fallback to original URL
+  console.log(`Falling back to standard download URL: ${versionDownloadUrl}`);
+  res = await fetchFile(versionDownloadUrl);
+  res = await handleExternalRedirects(res, id);
+
+  console.log(`Downloaded: ${res.url}`, {
+    status: res.status,
+    statusText: res.statusText,
+    disposition: res.headers.get('content-disposition'),
+    type: res.headers.get('content-type'),
+  });
+
+  const [filename, archivePath] = await saveDownloadedFile(res, id);
+  return { isCached: false, filename, archivePath };
+}

--- a/apps/api/src/mods/utils/errors.ts
+++ b/apps/api/src/mods/utils/errors.ts
@@ -1,0 +1,17 @@
+/**
+ * If this error is thrown, the mod version will be skipped and not processed further
+ * again, as it's impossible to install it.
+ */
+export class SkipInstallError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SkipInstallError';
+  }
+}
+
+export class DownloadError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'DownloadError';
+  }
+}

--- a/apps/api/src/mods/utils/extract/extractArchive.ts
+++ b/apps/api/src/mods/utils/extract/extractArchive.ts
@@ -1,0 +1,106 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { unpack, cmd } from '7zip-min';
+import * as unrar from 'node-unrar-js';
+import { SkipInstallError } from '../errors';
+
+// Extract ZIP and 7z using `7zip-min`
+async function extract7ZipOrZip(
+  archivePath: string,
+  extractTo: string
+): Promise<void> {
+  try {
+    const isTarGz =
+      archivePath.endsWith('.tar.gz') || archivePath.endsWith('.tgz');
+
+    let args = ['x', archivePath, '-y', '-o' + extractTo];
+
+    if (archivePath.endsWith('.tgz')) {
+      args.push('-tgzip');
+    }
+
+    await cmd(args);
+
+    if (isTarGz) {
+      // Gets tar path e.g. "abc.tgz" -> "abc.tar", or "abc.tar.gz" -> "abc.tar"
+      const tarPath = path.join(
+        extractTo,
+        path.basename(archivePath, path.extname(archivePath)) + '.tar'
+      );
+
+      console.log('Extracting tar.gz file from', tarPath);
+      await unpack(tarPath, extractTo);
+      await fs.rm(tarPath);
+    }
+  } catch (error) {
+    throw new Error(`7zip extraction failed: ${error}`);
+  }
+}
+
+// Extract RAR using `node-unrar-js`
+async function extractRar(
+  archivePath: string,
+  extractTo: string
+): Promise<void> {
+  const extractor = await unrar.createExtractorFromFile({
+    filepath: archivePath,
+    targetPath: extractTo,
+  });
+  const extractedFiles = extractor.extract();
+
+  await fs.mkdir(extractTo, { recursive: true });
+
+  for (const file of extractedFiles.files) {
+    if (!file.fileHeader.flags.directory) {
+      // const filePath = path.join(extractTo, file.fileHeader.name);
+      // Trigger extraction
+      file.extraction;
+    }
+  }
+}
+
+// Function to extract an archive based on its format
+export async function extractArchive(
+  archivePath: string,
+  extractTo: string
+): Promise<void> {
+  if (
+    archivePath.endsWith('.zip') ||
+    archivePath.endsWith('.7z') ||
+    archivePath.endsWith('.tar.gz') ||
+    archivePath.endsWith('.tgz') ||
+    archivePath.endsWith('.tar') ||
+    archivePath.endsWith('.gz') ||
+    archivePath.endsWith('.bz2')
+  ) {
+    await extract7ZipOrZip(archivePath, extractTo);
+  } else if (archivePath.endsWith('.rar')) {
+    await extractRar(archivePath, extractTo);
+  } else {
+    throw new SkipInstallError(`Unsupported archive format: ${archivePath}`);
+  }
+
+  // Ensure all files have sufficient permissions
+  try {
+    await recursivelyGrantReadWritePermissions(extractTo);
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+async function recursivelyGrantReadWritePermissions(
+  directory: string
+): Promise<void> {
+  const entries = [path.resolve(directory)];
+  while (entries.length > 0) {
+    const entry = entries.pop()!;
+    const stat = await fs.stat(entry);
+    await fs.chmod(entry, stat.mode | fs.constants.O_RDWR);
+    if (stat.isDirectory()) {
+      const subEntries = (await fs.readdir(entry)).map((subEntry) =>
+        path.join(entry, subEntry)
+      );
+      entries.push(...subEntries);
+    }
+  }
+}

--- a/apps/api/src/mods/utils/extractAndStoreModVersionMetadata.ts
+++ b/apps/api/src/mods/utils/extractAndStoreModVersionMetadata.ts
@@ -2,35 +2,22 @@ import fs from 'fs/promises';
 import path from 'path';
 import crypto from 'crypto';
 import { XMLParser } from 'fast-xml-parser';
-import { unpack } from '7zip-min';
-import * as unrar from 'node-unrar-js';
 import sleep from 'sleep-promise';
-import { ModsRecord, ModVersionsRecord } from '@civmods/parser';
+import {
+  ModsRecord,
+  ModVersionsRecord,
+  parseContentDisposition,
+} from '@civmods/parser';
 import { ScrapeModsOptions, SyncModVersion } from './scrapeMods';
 import { pb } from '../../core/pocketbase';
 import { DiscordLog } from '../../integrations/discord/DiscordLog';
 import { upsertVersionMetadata } from './upsertVersionMetadata';
-
-const ARCHIVE_DIR = './apps/api/data/archives/';
-export const EXTRACTED_DIR = './apps/api/data/extracted/';
-
-/**
- * If this error is thrown, the mod version will be skipped and not processed further
- * again, as it's impossible to install it.
- */
-class SkipInstallError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'SkipInstallError';
-  }
-}
-
-class DownloadError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'DownloadError';
-  }
-}
+import { DownloadError, SkipInstallError } from './errors';
+import { extractArchive } from './extract/extractArchive';
+import { getFilesRecursively } from './fs/getFilesRecursively';
+import { ARCHIVE_DIR, EXTRACTED_DIR } from './fs/extractionDirs';
+import { downloadVersionFile } from './download/downloadVersionFile';
+import { getModInfoDependencies } from './modinfo/getModInfoDependencies';
 
 export async function extractAndStoreModVersionMetadata(
   options: ScrapeModsOptions,
@@ -40,8 +27,10 @@ export async function extractAndStoreModVersionMetadata(
   await fs.mkdir(ARCHIVE_DIR, { recursive: true });
   await fs.mkdir(EXTRACTED_DIR, { recursive: true });
 
-  let archivePath: string | null = null;
   let archiveSize = 0;
+  let archivePath: string | null = null;
+  let filename: string | null = null;
+  let isCached: boolean = false;
   const extractPath = path.join(EXTRACTED_DIR, version.id);
 
   try {
@@ -57,8 +46,13 @@ export async function extractAndStoreModVersionMetadata(
     if (!isAlreadyDownloaded?.isDirectory) {
       // Download archive
       console.log(`Downloading: ${version.download_url}`);
-      archivePath = await downloadFile(version.download_url, version.id);
-      if (!archivePath) return;
+      const download = await downloadVersionFile(
+        version.download_url,
+        version.id
+      );
+      archivePath = download.archivePath;
+      isCached = download.isCached;
+      filename = download.filename;
 
       console.log(`Downloaded: ${archivePath}`);
       archiveSize = (await fs.stat(archivePath)).size;
@@ -71,7 +65,10 @@ export async function extractAndStoreModVersionMetadata(
       // Compute archive hash
       archiveHash = await computeFileHash(archivePath);
 
-      const sleepTime = Math.floor(Math.random() * (2000 - 300 + 1)) + 1000; // Random sleep between 1-2 seconds
+      const sleepTime = isCached
+        ? 100
+        : Math.floor(Math.random() * (2000 - 300 + 1)) + 1000; // Random sleep between 1-2 seconds
+
       console.log(`Sleeping for ${sleepTime} ms`);
       await sleep(sleepTime);
     } else {
@@ -110,6 +107,7 @@ export async function extractAndStoreModVersionMetadata(
         modInfo?.Mod?.Properties?.AffectsSavedGames == 1 ||
         modInfo?.Mod?.Properties?.AffectsSavedGames == null,
       archive_size: archiveSize,
+      dependencies: getModInfoDependencies(modInfo),
       skip_install: false,
       download_error: false,
       is_processing: false,
@@ -125,6 +123,8 @@ export async function extractAndStoreModVersionMetadata(
         versionId: version.id,
         modInfo,
         archivePath,
+        filename,
+        skipFileUpload: isCached,
       });
     } catch (error) {
       console.error(`Failed to store metadata for ${version.name}: ${error}`);
@@ -132,11 +132,15 @@ export async function extractAndStoreModVersionMetadata(
     }
 
     console.log(`Updated PocketBase for: ${version.name}`);
-    DiscordLog.onVersionProcessed(mod, { ...version, ...versionUpdate });
+    if (!options.forceExtractAndStore) {
+      DiscordLog.onVersionProcessed(mod, { ...version, ...versionUpdate });
+    }
   } catch (error) {
     console.error(`Failed to process ${version.name}: ${error}`);
     console.error(error);
-    DiscordLog.onVersionError(mod, version, error);
+    if (!options.forceExtractAndStore) {
+      DiscordLog.onVersionError(mod, version, error);
+    }
 
     /**
      * If the error is a SkipInstallError, mark the version as skipped and not
@@ -162,7 +166,7 @@ export async function extractAndStoreModVersionMetadata(
         } as ModVersionsRecord);
     }
   } finally {
-    if (process.env.NODE_ENV !== 'development') {
+    if (process.env.NODE_ENV !== 'development' || true) {
       console.log(`Cleaning up: ${version.name}, NODE_ENV: ${process.env.NODE_ENV}`); // prettier-ignore
       try {
         if (archivePath) await fs.rm(archivePath);
@@ -193,50 +197,12 @@ export async function computeFolderHash(folderPath: string): Promise<string> {
   console.log(`Hashing folder: ${folderPath}`);
 
   for (const file of files) {
-    // Skipping for now
-
-    // Get the relative path
-    // const relativePath = path.relative(folderPath, file);
-    // console.log(` Hashing: ${relativePath}`);
-
-    // // Update hash with the relative path
-    // hash.update(relativePath);
-
     // Read file content and update hash
     const content = await fs.readFile(file);
     hash.update(content);
   }
 
   return hash.digest('hex');
-}
-
-// Utility: Recursively list all files in a directory
-async function getFilesRecursively(directory: string): Promise<string[]> {
-  let files: string[] = [];
-  const entries = await fs.readdir(directory, { withFileTypes: true });
-  const orderedEntries = entries.sort((a, b) => {
-    const aLower = a.name.toLowerCase();
-    const bLower = b.name.toLowerCase();
-    if (aLower < bLower) return -1;
-    if (aLower > bLower) return 1;
-    return 0;
-  });
-
-  for (const entry of orderedEntries) {
-    const entryPath = path.join(directory, entry.name);
-
-    // Make sure this is aligned with the ignore list in the frontend in rust
-    if (entry.name.startsWith('.')) continue;
-    if (entry.name.toLowerCase() === 'thumbs.db') continue;
-    if (entry.name.toLowerCase() === '__MACOSX') continue;
-    if (entry.isDirectory()) {
-      files = files.concat(await getFilesRecursively(entryPath));
-    } else {
-      files.push(entryPath);
-    }
-  }
-
-  return files;
 }
 
 // Utility: Recursively find .modinfo file
@@ -248,171 +214,4 @@ export async function findModInfoFile(
     files.find((file) => file.endsWith('.modinfo') && !file.startsWith('.')) ||
     null
   );
-}
-
-// Extract ZIP and 7z using `7zip-min`
-async function extract7ZipOrZip(
-  archivePath: string,
-  extractTo: string
-): Promise<void> {
-  return new Promise((resolve, reject) => {
-    unpack(archivePath, extractTo, (err) => {
-      if (err) reject(`7zip extraction failed: ${err}`);
-      else resolve();
-    });
-  });
-}
-
-// Extract RAR using `node-unrar-js`
-async function extractRar(
-  archivePath: string,
-  extractTo: string
-): Promise<void> {
-  const extractor = await unrar.createExtractorFromFile({
-    filepath: archivePath,
-    targetPath: extractTo,
-  });
-  const extractedFiles = extractor.extract();
-
-  await fs.mkdir(extractTo, { recursive: true });
-
-  for (const file of extractedFiles.files) {
-    if (!file.fileHeader.flags.directory) {
-      // const filePath = path.join(extractTo, file.fileHeader.name);
-      // Trigger extraction
-      file.extraction;
-    }
-  }
-}
-
-// Function to extract an archive based on its format
-async function extractArchive(
-  archivePath: string,
-  extractTo: string
-): Promise<void> {
-  if (
-    archivePath.endsWith('.zip') ||
-    archivePath.endsWith('.7z') ||
-    archivePath.endsWith('.tar.gz') ||
-    archivePath.endsWith('.tgz') ||
-    archivePath.endsWith('.tar') ||
-    archivePath.endsWith('.gz') ||
-    archivePath.endsWith('.bz2')
-  ) {
-    await extract7ZipOrZip(archivePath, extractTo);
-  } else if (archivePath.endsWith('.rar')) {
-    await extractRar(archivePath, extractTo);
-  } else {
-    throw new SkipInstallError(`Unsupported archive format: ${archivePath}`);
-  }
-
-  // Ensure all files have sufficient permissions
-  try {
-    await recursivelyGrantReadWritePermissions(extractTo);
-  } catch (error) {
-    console.error(error);
-  }
-}
-
-async function recursivelyGrantReadWritePermissions(
-  directory: string
-): Promise<void> {
-  const entries = [path.resolve(directory)];
-  while (entries.length > 0) {
-    const entry = entries.pop()!;
-    const stat = await fs.stat(entry);
-    await fs.chmod(entry, stat.mode | fs.constants.O_RDWR);
-    if (stat.isDirectory()) {
-      const subEntries = (await fs.readdir(entry)).map((subEntry) =>
-        path.join(entry, subEntry)
-      );
-      entries.push(...subEntries);
-    }
-  }
-}
-
-/**
- * Converts a Google Drive file URL into a direct download link.
- * @param url - The original Google Drive file URL
- * @returns Direct download URL or null if invalid
- */
-function getGoogleDriveDirectDownloadUrl(url: string): string | null {
-  const match = url.match(/drive\.google\.com\/file\/d\/([^/]+)/);
-  if (match && match[1]) {
-    return `https://drive.google.com/uc?export=download&id=${match[1]}`;
-  }
-  return null;
-}
-
-// Utility: Download a file
-async function downloadFile(url: string, id: string): Promise<string | null> {
-  let res = await fetch(url, {
-    headers: {
-      'User-Agent': 'CivMods/1.0',
-    },
-  });
-  if (!res.ok) throw new Error(`Failed to download ${url}`);
-
-  if (res.redirected) {
-    await pb.collection('mod_versions').update(id, {
-      is_external_download: true,
-    } as Partial<ModVersionsRecord>);
-  }
-
-  if (res.redirected && res.url.includes('//drive.google.com/')) {
-    const updatedUrl = getGoogleDriveDirectDownloadUrl(res.url);
-    if (!updatedUrl) {
-      console.warn(`Failed to get direct download link for ${url}`);
-      return null;
-    }
-
-    res = await fetch(updatedUrl);
-    if (!res.ok) throw new Error(`Failed to download ${updatedUrl}`);
-  }
-
-  console.log(`Downloaded: ${url}`, {
-    status: res.status,
-    statusText: res.statusText,
-    disposition: res.headers.get('content-disposition'),
-    type: res.headers.get('content-type'),
-  });
-
-  const buffer = await res.arrayBuffer();
-  const { filename, extension } = parseContentDisposition(
-    res.headers.get('content-disposition')
-  );
-
-  if (extension == null) {
-    console.warn(`No extension found for ${url}`, { filename, extension });
-    throw new DownloadError(
-      `No extension found for ${url}. Filename: ${filename}, Extension: ${extension}`
-    );
-  }
-
-  await fs.writeFile(
-    path.join(ARCHIVE_DIR, `${id}.${extension}`),
-    Buffer.from(buffer)
-  );
-
-  return path.join(ARCHIVE_DIR, `${id}.${extension}`);
-}
-
-function parseContentDisposition(contentDisposition: string | null): {
-  filename?: string;
-  extension?: string;
-} {
-  if (!contentDisposition) return {};
-
-  const match = contentDisposition.match(
-    /filename\*?=(?:UTF-8'')?([^;\r\n]*)/i
-  );
-  if (match && match[1]) {
-    let filename = decodeURIComponent(match[1].replace(/['"]/g, '')); // Remove quotes
-    let extension = filename.includes('.')
-      ? filename.split('.').pop()
-      : undefined;
-    return { filename, extension };
-  }
-
-  return {};
 }

--- a/apps/api/src/mods/utils/fs/extractionDirs.ts
+++ b/apps/api/src/mods/utils/fs/extractionDirs.ts
@@ -1,0 +1,2 @@
+export const ARCHIVE_DIR = './apps/api/data/archives/';
+export const EXTRACTED_DIR = './apps/api/data/extracted/';

--- a/apps/api/src/mods/utils/fs/getFilesRecursively.ts
+++ b/apps/api/src/mods/utils/fs/getFilesRecursively.ts
@@ -1,0 +1,35 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+/**
+ * Utility: Recursively list all files in a directory
+ */
+export async function getFilesRecursively(
+  directory: string
+): Promise<string[]> {
+  let files: string[] = [];
+  const entries = await fs.readdir(directory, { withFileTypes: true });
+  const orderedEntries = entries.sort((a, b) => {
+    const aLower = a.name.toLowerCase();
+    const bLower = b.name.toLowerCase();
+    if (aLower < bLower) return -1;
+    if (aLower > bLower) return 1;
+    return 0;
+  });
+
+  for (const entry of orderedEntries) {
+    const entryPath = path.join(directory, entry.name);
+
+    // Make sure this is aligned with the ignore list in the frontend in rust
+    if (entry.name.startsWith('.')) continue;
+    if (entry.name.toLowerCase() === 'thumbs.db') continue;
+    if (entry.name.toLowerCase() === '__MACOSX') continue;
+    if (entry.isDirectory()) {
+      files = files.concat(await getFilesRecursively(entryPath));
+    } else {
+      files.push(entryPath);
+    }
+  }
+
+  return files;
+}

--- a/apps/api/src/mods/utils/modinfo/getModInfoDependencies.ts
+++ b/apps/api/src/mods/utils/modinfo/getModInfoDependencies.ts
@@ -1,0 +1,13 @@
+import { parseXmlArray } from './parseXml';
+
+export function getModInfoDependencies(modInfo: any) {
+  const dependencies = parseXmlArray(modInfo?.Mod?.Dependencies?.Mod).map(
+    (dep: any) => {
+      return {
+        id: dep?.['@_id'] || null,
+      };
+    }
+  );
+
+  return dependencies;
+}

--- a/apps/api/src/mods/utils/modinfo/parseXml.ts
+++ b/apps/api/src/mods/utils/modinfo/parseXml.ts
@@ -1,0 +1,5 @@
+export function parseXmlArray(xml: any) {
+  if (!xml) return [];
+  if (Array.isArray(xml)) return xml;
+  return [xml];
+}

--- a/apps/api/src/mods/utils/saveModsToDatabase.ts
+++ b/apps/api/src/mods/utils/saveModsToDatabase.ts
@@ -144,7 +144,10 @@ export async function saveModToDatabase(
   if (isNewVersionsAvailable && !options.skipExtractAndStore) {
     for (const version of processableVersions) {
       console.log(`[mod=${mod.name}] Processing version: ${version.name}`);
-      DiscordLog.onVersionProcessing(mod, version);
+      if (!options.forceExtractAndStore) {
+        DiscordLog.onVersionProcessing(mod, version);
+      }
+
       await extractAndStoreModVersionMetadata(options, mod, version);
     }
   }

--- a/apps/api/src/mods/utils/scrapeMods.ts
+++ b/apps/api/src/mods/utils/scrapeMods.ts
@@ -267,14 +267,14 @@ export async function scrapeMods(
 
       console.log(`Mod JSON:`, JSON.stringify(mod, null, 2));
 
-      if (stopAfterFirstMod) {
-        process.exit(0); // Exit after first mod for testing
-      }
-
       // Save mod
       const shouldStop = await saveModToDatabase(options, mod);
       if (shouldStop) {
         return mods;
+      }
+
+      if (stopAfterFirstMod) {
+        process.exit(0); // Exit after first mod for testing
       }
 
       if (!options.onlyListData) {

--- a/apps/api/src/mods/utils/upsertVersionMetadata.ts
+++ b/apps/api/src/mods/utils/upsertVersionMetadata.ts
@@ -1,0 +1,49 @@
+import { ModVersionsMetadataRecord } from '@civmods/parser';
+import { pb } from '../../core/pocketbase';
+import { ScrapeModsOptions } from './scrapeMods';
+import fs from 'fs';
+
+export interface UpsertVersionMetadataInput {
+  modId: string;
+  versionId: string;
+  modInfo: any;
+  archivePath: string | null | undefined;
+}
+
+export async function upsertVersionMetadata(
+  options: ScrapeModsOptions,
+  input: UpsertVersionMetadataInput
+) {
+  const { modId, versionId, modInfo } = input;
+  const metadata = await pb
+    .collection('mod_versions_metadata')
+    .getList(1, 1, {
+      filter: pb.filter(`version_id = {:version_id}`, {
+        version_id: versionId,
+      }),
+    })
+    .then((res) => res?.items?.[0]);
+
+  const partialMetadata = {
+    version_id: versionId,
+    content: modInfo,
+  } as Partial<ModVersionsMetadataRecord>;
+
+  if (input.archivePath) {
+    partialMetadata.archive_file = new Blob([
+      fs.readFileSync(input.archivePath),
+    ]) as any;
+  } else {
+    console.log(
+      `No archive file found for mod: ${modId} (already downloaded?)`
+    );
+  }
+
+  if (!metadata) {
+    await pb.collection('mod_versions_metadata').create(partialMetadata);
+  } else {
+    await pb
+      .collection('mod_versions_metadata')
+      .update(metadata.id, partialMetadata);
+  }
+}

--- a/apps/api/src/mods/utils/upsertVersionMetadata.ts
+++ b/apps/api/src/mods/utils/upsertVersionMetadata.ts
@@ -2,12 +2,19 @@ import { ModVersionsMetadataRecord } from '@civmods/parser';
 import { pb } from '../../core/pocketbase';
 import { ScrapeModsOptions } from './scrapeMods';
 import fs from 'fs';
+import { findModVersionMetadata } from './db/versionMetadataRepo';
+import path from 'path';
 
 export interface UpsertVersionMetadataInput {
   modId: string;
   versionId: string;
   modInfo: any;
   archivePath: string | null | undefined;
+  filename: string | null | undefined;
+  /**
+   * Useful if the file is already downloaded and you want to skip the upload.
+   */
+  skipFileUpload?: boolean;
 }
 
 export async function upsertVersionMetadata(
@@ -15,28 +22,24 @@ export async function upsertVersionMetadata(
   input: UpsertVersionMetadataInput
 ) {
   const { modId, versionId, modInfo } = input;
-  const metadata = await pb
-    .collection('mod_versions_metadata')
-    .getList(1, 1, {
-      filter: pb.filter(`version_id = {:version_id}`, {
-        version_id: versionId,
-      }),
-    })
-    .then((res) => res?.items?.[0]);
+  const metadata = await findModVersionMetadata(versionId);
 
   const partialMetadata = {
     version_id: versionId,
     content: modInfo,
   } as Partial<ModVersionsMetadataRecord>;
 
-  if (input.archivePath) {
-    partialMetadata.archive_file = new Blob([
-      fs.readFileSync(input.archivePath),
-    ]) as any;
-  } else {
-    console.log(
-      `No archive file found for mod: ${modId} (already downloaded?)`
-    );
+  if (!input.skipFileUpload) {
+    if (input.archivePath) {
+      partialMetadata.archive_file = new File(
+        [fs.readFileSync(input.archivePath)],
+        input.filename ?? path.basename(input.archivePath)
+      ) as any;
+    } else {
+      console.log(
+        `No archive file found for mod: ${modId} (already downloaded?)`
+      );
+    }
   }
 
   if (!metadata) {

--- a/apps/api/src/scripts/hash-folder.ts
+++ b/apps/api/src/scripts/hash-folder.ts
@@ -2,9 +2,9 @@ import path from 'path';
 import { pb } from '../core/pocketbase';
 import {
   computeFolderHash,
-  EXTRACTED_DIR,
   findModInfoFile,
 } from '../mods/utils/extractAndStoreModVersionMetadata';
+import { EXTRACTED_DIR } from '../mods/utils/fs/extractionDirs';
 
 async function hashFolder() {
   const version = await pb

--- a/apps/api/src/scripts/import-fanatics-mods.ts
+++ b/apps/api/src/scripts/import-fanatics-mods.ts
@@ -3,7 +3,7 @@ import { scrapeMods } from '../mods/utils/scrapeMods';
 const singleModUrl =
   'https://forums.civfanatics.com/resources/higher-relics-count-for-cultural-victory-in-exploration-age-by-rico.31926/';
 
-const forceExtractAndStore = false;
+const forceExtractAndStore = true;
 const maxPages = 1; // 15 full
 const stopAfterLastModVersion = true;
 const onlyListData = false;
@@ -16,6 +16,7 @@ scrapeMods({
   forceExtractAndStore,
   stopAfterLastModVersion,
   onlyListData,
+  stopAfterFirstMod: true,
 })
   .then((mods) => {
     // fs.writeFileSync('civ7_mods.json', JSON.stringify(mods, null, 2));

--- a/apps/api/src/scripts/import-fanatics-mods.ts
+++ b/apps/api/src/scripts/import-fanatics-mods.ts
@@ -5,7 +5,7 @@ const singleModUrl =
 
 const forceExtractAndStore = true;
 const maxPages = 1; // 15 full
-const stopAfterLastModVersion = true;
+const stopAfterLastModVersion = false;
 const onlyListData = false;
 
 // Main entry point
@@ -16,7 +16,7 @@ scrapeMods({
   forceExtractAndStore,
   stopAfterLastModVersion,
   onlyListData,
-  stopAfterFirstMod: true,
+  stopAfterFirstMod: false,
 })
   .then((mods) => {
     // fs.writeFileSync('civ7_mods.json', JSON.stringify(mods, null, 2));

--- a/apps/api/src/scripts/import-fanatics-mods.ts
+++ b/apps/api/src/scripts/import-fanatics-mods.ts
@@ -1,7 +1,13 @@
 import { scrapeMods } from '../mods/utils/scrapeMods';
 
+// Test for dependencies:
+// 'https://forums.civfanatics.com/resources/custom-alerts-framework.32005/';
+// 'https://forums.civfanatics.com/resources/purchase-alerts.32034/';
+// https://forums.civfanatics.com/resources/matts-leaders-oliver-cromwell.32128/
+// https://forums.civfanatics.com/resources/addon-leader-model-changer.32124/
+
 const singleModUrl =
-  'https://forums.civfanatics.com/resources/higher-relics-count-for-cultural-victory-in-exploration-age-by-rico.31926/';
+  'https://forums.civfanatics.com/resources/addon-leader-model-changer.32124/';
 
 const forceExtractAndStore = true;
 const maxPages = 1; // 15 full
@@ -12,7 +18,7 @@ const onlyListData = false;
 scrapeMods({
   firstPage: 1,
   maxPages,
-  // singleModUrl,
+  singleModUrl,
   forceExtractAndStore,
   stopAfterLastModVersion,
   onlyListData,

--- a/apps/backend/pb_migrations/1743032684_created_mod_versions_metadata.js
+++ b/apps/backend/pb_migrations/1743032684_created_mod_versions_metadata.js
@@ -1,0 +1,94 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => {
+  const collection = new Collection({
+    "createRule": null,
+    "deleteRule": null,
+    "fields": [
+      {
+        "autogeneratePattern": "[a-z0-9]{15}",
+        "hidden": false,
+        "id": "text3208210256",
+        "max": 15,
+        "min": 15,
+        "name": "id",
+        "pattern": "^[a-z0-9]+$",
+        "presentable": false,
+        "primaryKey": true,
+        "required": true,
+        "system": true,
+        "type": "text"
+      },
+      {
+        "hidden": false,
+        "id": "json4274335913",
+        "maxSize": 0,
+        "name": "content",
+        "presentable": false,
+        "required": false,
+        "system": false,
+        "type": "json"
+      },
+      {
+        "cascadeDelete": true,
+        "collectionId": "pbc_1350908007",
+        "hidden": false,
+        "id": "relation1270621957",
+        "maxSelect": 1,
+        "minSelect": 0,
+        "name": "version_id",
+        "presentable": false,
+        "required": false,
+        "system": false,
+        "type": "relation"
+      },
+      {
+        "hidden": false,
+        "id": "file3166363787",
+        "maxSelect": 1,
+        "maxSize": 100,
+        "mimeTypes": [],
+        "name": "archive_file",
+        "presentable": false,
+        "protected": true,
+        "required": false,
+        "system": false,
+        "thumbs": [],
+        "type": "file"
+      },
+      {
+        "hidden": false,
+        "id": "autodate2990389176",
+        "name": "created",
+        "onCreate": true,
+        "onUpdate": false,
+        "presentable": false,
+        "system": false,
+        "type": "autodate"
+      },
+      {
+        "hidden": false,
+        "id": "autodate3332085495",
+        "name": "updated",
+        "onCreate": true,
+        "onUpdate": true,
+        "presentable": false,
+        "system": false,
+        "type": "autodate"
+      }
+    ],
+    "id": "pbc_3646822515",
+    "indexes": [],
+    "listRule": null,
+    "name": "mod_versions_metadata",
+    "system": false,
+    "type": "base",
+    "updateRule": null,
+    "viewRule": null
+  });
+
+  return app.save(collection);
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("pbc_3646822515");
+
+  return app.delete(collection);
+})

--- a/apps/backend/pb_migrations/1743032895_updated_mod_versions.js
+++ b/apps/backend/pb_migrations/1743032895_updated_mod_versions.js
@@ -1,0 +1,44 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId("pbc_1350908007")
+
+  // remove field
+  collection.fields.removeById("text3518522040")
+
+  // add field
+  collection.fields.addAt(8, new Field({
+    "hidden": false,
+    "id": "json3926880397",
+    "maxSize": 0,
+    "name": "dependencies",
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "json"
+  }))
+
+  return app.save(collection)
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("pbc_1350908007")
+
+  // add field
+  collection.fields.addAt(9, new Field({
+    "autogeneratePattern": "",
+    "hidden": false,
+    "id": "text3518522040",
+    "max": 0,
+    "min": 0,
+    "name": "hash",
+    "pattern": "",
+    "presentable": false,
+    "primaryKey": false,
+    "required": false,
+    "system": false,
+    "type": "text"
+  }))
+
+  // remove field
+  collection.fields.removeById("json3926880397")
+
+  return app.save(collection)
+})

--- a/apps/backend/pb_migrations/1743033084_updated_mod_versions_metadata.js
+++ b/apps/backend/pb_migrations/1743033084_updated_mod_versions_metadata.js
@@ -1,0 +1,52 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId("pbc_3646822515")
+
+  // update collection data
+  unmarshal({
+    "indexes": [
+      "CREATE UNIQUE INDEX `idx_LMSLjIUEnJ` ON `mod_versions_metadata` (`version_id`)"
+    ]
+  }, collection)
+
+  // update field
+  collection.fields.addAt(2, new Field({
+    "cascadeDelete": true,
+    "collectionId": "pbc_1350908007",
+    "hidden": false,
+    "id": "relation1270621957",
+    "maxSelect": 1,
+    "minSelect": 0,
+    "name": "version_id",
+    "presentable": false,
+    "required": true,
+    "system": false,
+    "type": "relation"
+  }))
+
+  return app.save(collection)
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("pbc_3646822515")
+
+  // update collection data
+  unmarshal({
+    "indexes": []
+  }, collection)
+
+  // update field
+  collection.fields.addAt(2, new Field({
+    "cascadeDelete": true,
+    "collectionId": "pbc_1350908007",
+    "hidden": false,
+    "id": "relation1270621957",
+    "maxSelect": 1,
+    "minSelect": 0,
+    "name": "version_id",
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "relation"
+  }))
+
+  return app.save(collection)
+})

--- a/apps/backend/pb_migrations/1743035562_updated_mod_versions_metadata.js
+++ b/apps/backend/pb_migrations/1743035562_updated_mod_versions_metadata.js
@@ -1,0 +1,42 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId("pbc_3646822515")
+
+  // update field
+  collection.fields.addAt(3, new Field({
+    "hidden": false,
+    "id": "file3166363787",
+    "maxSelect": 1,
+    "maxSize": 209715200,
+    "mimeTypes": [],
+    "name": "archive_file",
+    "presentable": false,
+    "protected": true,
+    "required": false,
+    "system": false,
+    "thumbs": [],
+    "type": "file"
+  }))
+
+  return app.save(collection)
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("pbc_3646822515")
+
+  // update field
+  collection.fields.addAt(3, new Field({
+    "hidden": false,
+    "id": "file3166363787",
+    "maxSelect": 1,
+    "maxSize": 100,
+    "mimeTypes": [],
+    "name": "archive_file",
+    "presentable": false,
+    "protected": true,
+    "required": false,
+    "system": false,
+    "thumbs": [],
+    "type": "file"
+  }))
+
+  return app.save(collection)
+})

--- a/apps/desktop/src/home/Home.tsx
+++ b/apps/desktop/src/home/Home.tsx
@@ -346,6 +346,8 @@ export default function ModsListPage() {
                         {update.fetched.name}:{' '}
                         {update.mod.installedVersion?.name} →{' '}
                         {update.targetVersion?.name}
+                        {!update.mod.areDependenciesSatisfied &&
+                          ` (will install missing dependencies)`}
                       </Text>
                     ))}
                   </Stack>

--- a/apps/desktop/src/home/IModInfo.ts
+++ b/apps/desktop/src/home/IModInfo.ts
@@ -25,7 +25,10 @@ export type ModData = {
   installedVersion?: ModVersionsRecord;
   isUnknown: boolean;
   isLocalOnly: boolean;
+  dependedBy: string[];
+  dependsOn: string[];
   id: string;
   name: string;
   modinfo_id?: string;
+  areDependenciesSatisfied: boolean;
 };

--- a/apps/desktop/src/home/IModInfo.ts
+++ b/apps/desktop/src/home/IModInfo.ts
@@ -15,6 +15,10 @@ export interface ModInfo {
   folder_name: string;
 }
 
+export type ModDependency = {
+  id: string;
+};
+
 export type ModData = {
   fetched?: FetchedMod;
   local: ModInfo | null | undefined;

--- a/apps/desktop/src/mods/ModBox.module.css
+++ b/apps/desktop/src/mods/ModBox.module.css
@@ -19,12 +19,6 @@
   border-color: #5a5c61;
 }
 
-.modIcon {
-  width: 40px;
-  height: 40px;
-  border-radius: 4px;
-}
-
 .localOnly {
   /* background-color: var(--mantine-color-orange-8); */
 }

--- a/apps/desktop/src/mods/ModBox.tsx
+++ b/apps/desktop/src/mods/ModBox.tsx
@@ -60,6 +60,7 @@ import { useAppStore } from '../store/store';
 import { notifications } from '@mantine/notifications';
 import { cleanCategoryName } from './modCategory';
 import { SetModsQueryFn } from '../home/ModsQuery';
+import { ModIcon } from './components/ModIcon';
 
 export interface IModBoxProps {
   mod: ModData;
@@ -177,25 +178,7 @@ export function ModBox(props: IModBoxProps) {
         <LoadingOverlay visible={loading} />
         <Flex justify="space-between" align="flex-start">
           <Group justify="normal" wrap="nowrap" w="100%">
-            {fetched?.icon_url ? (
-              <Image
-                width={40}
-                height={40}
-                style={{ borderRadius: '4px' }}
-                src={fetched.icon_url}
-                alt={fetched.name}
-              />
-            ) : (
-              <Box
-                className={
-                  styles.modIcon +
-                  ' ' +
-                  (mod.isLocalOnly ? styles.localOnly : '')
-                }
-              >
-                <IconSettings size={40} />
-              </Box>
-            )}
+            <ModIcon mod={mod} width={40} />
             <Flex justify="space-between" w="100%">
               <Stack gap={0} align="flex-start" w="100%">
                 <Text fw={600}>

--- a/apps/desktop/src/mods/ModsContext.tsx
+++ b/apps/desktop/src/mods/ModsContext.tsx
@@ -209,7 +209,10 @@ export function ModsContextProvider(props: { children: React.ReactNode }) {
       }
     ) => {
       try {
-        let dependencies = await installModDependencies([mod], mods);
+        let dependencies = await installModDependencies(
+          [{ mod, version }],
+          mods
+        );
 
         if (!options?.onlyDependencies) {
           await installMod(mod, version);

--- a/apps/desktop/src/mods/ModsContext.tsx
+++ b/apps/desktop/src/mods/ModsContext.tsx
@@ -25,7 +25,7 @@ import { computeModsData } from './commands/computeModsData';
 import { getVersion } from '@tauri-apps/api/app';
 
 const pb = new PocketBase(
-  'https://backend.civmods.com'
+  import.meta.env.VITE_POCKETBASE_URL || 'https://backend.civmods.com'
   // 'http://localhost:8090'
 ) as TypedPocketBase;
 

--- a/apps/desktop/src/mods/checkUpdates.ts
+++ b/apps/desktop/src/mods/checkUpdates.ts
@@ -77,7 +77,10 @@ export function useApplyUpdates() {
     // because it will be installed in the next step
     try {
       const installedDeps = await installModDependencies(
-        availableUpdates.map((update) => update.mod),
+        availableUpdates.map((update) => ({
+          mod: update.mod,
+          version: update.targetVersion,
+        })),
         mods
       );
       if (installedDeps.length > 0) {

--- a/apps/desktop/src/mods/checkUpdates.ts
+++ b/apps/desktop/src/mods/checkUpdates.ts
@@ -6,6 +6,8 @@ import { useCallback, useMemo, useState } from 'react';
 import { isSameVersion } from './isSameVersion';
 import { useAppStore } from '../store/store';
 import { installMod } from './installMod';
+import { getModDependencies } from './dependencies/getModDependencies';
+import { installModDependencies } from './dependencies/installModDependencies';
 
 export interface IModUpdate {
   mod: ModData;
@@ -69,6 +71,29 @@ export function useApplyUpdates() {
     const lockedModIds = new Set(useAppStore.getState().lockedModIds ?? []);
 
     let errors = [];
+
+    // 1. Install dependencies first (only new ones)
+    // If a dependency is already in the update list, it will be skipped
+    // because it will be installed in the next step
+    try {
+      const installedDeps = await installModDependencies(
+        availableUpdates.map((update) => update.mod),
+        mods
+      );
+      if (installedDeps.length > 0) {
+        notifications.show({
+          color: 'blue',
+          title: 'Installed dependencies',
+          message: `Installed ${installedDeps.length} missing dependencies`,
+          autoClose: 5000,
+        });
+      }
+    } catch (error) {
+      errors.push(error);
+      console.error('Failed to install dependencies:', error);
+    }
+
+    // 2. Install mods updates
     for (const update of availableUpdates) {
       console.log('Applying update:', update.fetched.id);
       try {

--- a/apps/desktop/src/mods/commands/computeModsData.ts
+++ b/apps/desktop/src/mods/commands/computeModsData.ts
@@ -47,7 +47,14 @@ export function computeModsData(options: ComputeModsDataOptions): ModData[] {
       isSameVersion(version, local)
     );
 
-    const deps = latestVersion.dependencies as { id: string }[] | undefined;
+    // We want to track the dependencies of the installed version, if it exists,
+    // since the user might have installed a specific version of the mod that has
+    // _different_ dependencies than the latest version.
+    // If the installed version is not found, we fall back to the latest version.
+    const deps = (installedVersion ?? latestVersion).dependencies as
+      | { id: string }[]
+      | undefined;
+
     if (deps && deps.length > 0) {
       for (const dep of deps) {
         // modinfo_id → modinfo_id

--- a/apps/desktop/src/mods/commands/computeModsData.ts
+++ b/apps/desktop/src/mods/commands/computeModsData.ts
@@ -1,7 +1,5 @@
 import { FetchedMod, ModData, ModInfo } from '../../home/IModInfo';
-import { getActiveModsFolder } from '../getModsFolder';
 import { isSameVersion } from '../isSameVersion';
-import { invokeScanCivMods } from './modsRustBindings';
 
 export interface ComputeModsDataOptions {
   fetchedMods: FetchedMod[];
@@ -11,22 +9,56 @@ export interface ComputeModsDataOptions {
 export function computeModsData(options: ComputeModsDataOptions): ModData[] {
   const { fetchedMods, modsInfo } = options;
 
-  let locallyFoundInFetched = new Set<string>();
+  const locallyFoundInFetched = new Set<string>();
+  const dependencyMap = new Map<string, Set<string>>(); // modinfo_id -> modinfo_ids that depend on it
+  const dependsOnMap = new Map<string, Set<string>>(); // modinfo_id -> modinfo_ids it depends on
 
   const fetchedMapped: ModData[] = fetchedMods.map((fetchedMod) => {
-    const local = modsInfo.find(
-      (info) =>
-        info.modinfo_id ===
-        fetchedMod.expand?.mod_versions_via_mod_id[0].modinfo_id
-    );
+    const modVersions = fetchedMod.expand?.mod_versions_via_mod_id ?? [];
+    const latestVersion = modVersions[0];
+    const modinfoId = latestVersion?.modinfo_id;
+
+    if (!modinfoId) {
+      // If the modinfo_id is not present, we cannot map it to a local mod
+      // and we cannot determine if it's installed or not.
+      // This should not happen in a well-formed modinfo.
+      return {
+        id: fetchedMod.id,
+        fetched: fetchedMod,
+        local: undefined,
+        installedVersion: undefined,
+        isUnknown: false,
+        isLocalOnly: false,
+        name: fetchedMod.name,
+        modinfo_id: undefined,
+        dependedBy: [],
+        dependsOn: [],
+        areDependenciesSatisfied: true,
+      };
+    }
+
+    const local = modsInfo.find((info) => info.modinfo_id === modinfoId);
 
     if (local) {
       locallyFoundInFetched.add(local.folder_name);
     }
 
-    const installedVersion = fetchedMod.expand?.mod_versions_via_mod_id.find(
-      (version) => isSameVersion(version, local)
+    const installedVersion = modVersions.find((version) =>
+      isSameVersion(version, local)
     );
+
+    const deps = latestVersion.dependencies as { id: string }[] | undefined;
+    if (deps && deps.length > 0) {
+      for (const dep of deps) {
+        // modinfo_id → modinfo_id
+        if (!dependencyMap.has(dep.id)) dependencyMap.set(dep.id, new Set());
+        dependencyMap.get(dep.id)!.add(modinfoId);
+
+        if (!dependsOnMap.has(modinfoId))
+          dependsOnMap.set(modinfoId, new Set());
+        dependsOnMap.get(modinfoId)!.add(dep.id);
+      }
+    }
 
     return {
       id: fetchedMod.id,
@@ -36,29 +68,60 @@ export function computeModsData(options: ComputeModsDataOptions): ModData[] {
       isUnknown: !installedVersion && local != null,
       isLocalOnly: false,
       name: fetchedMod.name,
-      modinfo_id:
-        local?.modinfo_id ||
-        fetchedMod.expand?.mod_versions_via_mod_id[0].modinfo_id!,
+      modinfo_id: modinfoId,
+      dependedBy: [],
+      dependsOn: [],
+      areDependenciesSatisfied: true, // calculated later
     };
   });
 
-  return [
-    ...fetchedMapped,
-    ...modsInfo
-      .filter((info) => !locallyFoundInFetched.has(info.folder_name))
-      .map(
-        (info) =>
-          ({
-            id: info.folder_name + '-local',
-            fetched: undefined,
-            local: info,
-            installedVersion: undefined,
-            isUnknown: true,
-            isLocalOnly: true,
-            // TODO use the localized name, when we'll get it
-            name: info.modinfo_id ?? info.folder_name ?? 'Unknown mod',
-            modinfo_id: info.modinfo_id,
-          } as ModData)
-      ),
-  ];
+  const localOnly: ModData[] = modsInfo
+    .filter((info) => !locallyFoundInFetched.has(info.folder_name))
+    .map((info) => ({
+      id: info.folder_name + '-local',
+      fetched: undefined,
+      local: info,
+      installedVersion: undefined,
+      isUnknown: true,
+      isLocalOnly: true,
+      name: info.modinfo_id ?? info.folder_name ?? 'Unknown mod',
+      modinfo_id: info.modinfo_id,
+      dependedBy: [],
+      dependsOn: [],
+      areDependenciesSatisfied: true,
+    }));
+
+  const allMods: ModData[] = [...fetchedMapped, ...localOnly];
+  const modinfoIdMap = new Map<string, ModData>();
+
+  for (const mod of allMods) {
+    if (mod.modinfo_id) {
+      modinfoIdMap.set(mod.modinfo_id, mod);
+    }
+  }
+
+  // Assign `dependedBy`
+  for (const [depId, dependents] of dependencyMap.entries()) {
+    const depMod = modinfoIdMap.get(depId);
+    if (depMod) {
+      depMod.dependedBy = Array.from(dependents);
+    }
+  }
+
+  // Assign `dependsOn` and `areDependenciesSatisfied`
+  for (const [modinfoId, deps] of dependsOnMap.entries()) {
+    const mod = modinfoIdMap.get(modinfoId);
+    if (mod) {
+      const depsArray = Array.from(deps);
+      mod.dependsOn = depsArray;
+
+      mod.areDependenciesSatisfied = depsArray.every((depId) => {
+        const depMod = modinfoIdMap.get(depId);
+        if (!depMod) return true; // If the dependency is not found, we assume it's satisfied, e.g. DLCs
+        return depMod.local != null;
+      });
+    }
+  }
+
+  return allMods;
 }

--- a/apps/desktop/src/mods/components/ModIcon.module.css
+++ b/apps/desktop/src/mods/components/ModIcon.module.css
@@ -1,0 +1,3 @@
+.modIcon {
+  border-radius: 4px;
+}

--- a/apps/desktop/src/mods/components/ModIcon.tsx
+++ b/apps/desktop/src/mods/components/ModIcon.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { ModData } from '../../home/IModInfo';
+import { Box, Image } from '@mantine/core';
+import styles from './ModIcon.module.css';
+import { IconSettings } from '@tabler/icons-react';
+
+export interface IModIconProps {
+  mod?: ModData;
+  width?: number;
+}
+
+export function ModIcon(props: IModIconProps) {
+  const { mod, width = 40 } = props;
+  const fetched = mod?.fetched;
+
+  return fetched?.icon_url ? (
+    <Image
+      width={width}
+      height={width}
+      style={{ borderRadius: '4px' }}
+      src={fetched.icon_url}
+      alt={fetched.name}
+    />
+  ) : (
+    <Box
+      w={width}
+      h={width}
+      className={
+        styles.modIcon + ' ' + (mod?.isLocalOnly ? styles.localOnly : '')
+      }
+    >
+      <IconSettings size={width} />
+    </Box>
+  );
+}

--- a/apps/desktop/src/mods/components/ModSmallRow.tsx
+++ b/apps/desktop/src/mods/components/ModSmallRow.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { useModsContext } from '../ModsContext';
+import { useMemo } from 'react';
+import { Group, Text } from '@mantine/core';
+import { ModIcon } from './ModIcon';
+import { ModData } from '../../home/IModInfo';
+
+export interface IModSmallRowProps {
+  mod: ModData | undefined;
+  onClick?: React.MouseEventHandler<HTMLDivElement> | undefined;
+}
+
+export function ModSmallRow(props: IModSmallRowProps) {
+  const { mod } = props;
+  if (!mod) {
+    return null;
+  }
+
+  return (
+    <Group gap={'sm'} onClick={props.onClick}>
+      <ModIcon mod={mod} width={24} />
+      <Text size="sm" fw={500}>
+        {mod?.name ?? 'Unknown Mod'}
+      </Text>
+    </Group>
+  );
+}

--- a/apps/desktop/src/mods/components/ModUnsatisfiedDependenciesRow.tsx
+++ b/apps/desktop/src/mods/components/ModUnsatisfiedDependenciesRow.tsx
@@ -1,0 +1,75 @@
+import * as React from 'react';
+import { ModData } from '../../home/IModInfo';
+import { useModsContext } from '../ModsContext';
+import { Button, Group, Stack, Text, Tooltip } from '@mantine/core';
+import { useMemo } from 'react';
+import { getNotInstalledDependsOn } from '../dependencies/getInstalledDependsOn';
+import { ModSmallRow } from './ModSmallRow';
+import { notifications } from '@mantine/notifications';
+import { IconSettingsExclamation } from '@tabler/icons-react';
+
+export interface IModUnsatisfiedDependenciesRowProps {
+  mod: ModData;
+  setLoading: (loading: boolean) => void;
+}
+
+export function ModUnsatisfiedDependenciesRow(
+  props: IModUnsatisfiedDependenciesRowProps
+) {
+  const { mod, setLoading } = props;
+  const { mods, install } = useModsContext();
+
+  const shouldShow = mod.local != null && !mod.areDependenciesSatisfied;
+
+  const notInstalledDependsOn = useMemo(() => {
+    return getNotInstalledDependsOn(mod, mods);
+  }, [mod, mods]);
+
+  if (!shouldShow) {
+    return null;
+  }
+
+  return (
+    <Group>
+      <Tooltip
+        color="dark.8"
+        multiline
+        maw={300}
+        label={
+          <Stack gap={2}>
+            <Text size="sm" mb={'xs'}>
+              This mod has unsatisfied dependencies. Click to install them.
+            </Text>
+            {notInstalledDependsOn.map((dep) => (
+              <ModSmallRow key={dep.id} mod={dep} />
+            ))}
+          </Stack>
+        }
+      >
+        <Button
+          onClick={async () => {
+            try {
+              setLoading(true);
+
+              // We don't care about `installedVersion` here, we just want to install
+              // the dependencies.
+              await install(mod, mod.installedVersion!, {
+                onlyDependencies: true,
+              });
+            } finally {
+              // Error handling is done in the `install` function
+              setLoading(false);
+            }
+          }}
+          size="xs"
+          color="red"
+          mt="sm"
+          variant="light"
+          leftSection={<IconSettingsExclamation size={12} />}
+        >
+          Unsatisfied dependencies
+        </Button>
+      </Tooltip>
+    </Group>
+  );
+}

--- a/apps/desktop/src/mods/dependencies/DependencyInfo.ts
+++ b/apps/desktop/src/mods/dependencies/DependencyInfo.ts
@@ -1,0 +1,22 @@
+import { ModVersionsRecord } from '@civmods/parser';
+import { ModData } from '../../home/IModInfo';
+
+export type DependencyInfo = {
+  /**
+   * Modinfo ID of the mod
+   */
+  id: string;
+  modData?: ModData;
+  targetVersion?: ModVersionsRecord;
+  /**
+   * If a mod is present in the fetched list
+   * (i.e. it exists in the database)
+   */
+  isPresent: boolean;
+  /**
+   * If a mod is installed locally
+   * (i.e. it exists in the mods folder)
+   */
+  isInstalled: boolean;
+  shouldInstall: boolean;
+};

--- a/apps/desktop/src/mods/dependencies/DependencyInfo.ts
+++ b/apps/desktop/src/mods/dependencies/DependencyInfo.ts
@@ -1,6 +1,11 @@
 import { ModVersionsRecord } from '@civmods/parser';
 import { ModData } from '../../home/IModInfo';
 
+export interface ModInstallTarget {
+  mod: ModData;
+  version: ModVersionsRecord | undefined;
+}
+
 export type DependencyInfo = {
   /**
    * Modinfo ID of the mod

--- a/apps/desktop/src/mods/dependencies/getInstalledDependsOn.ts
+++ b/apps/desktop/src/mods/dependencies/getInstalledDependsOn.ts
@@ -1,0 +1,40 @@
+import { ModData } from '../../home/IModInfo';
+
+/**
+ * Get all mods that are installed and are dependencies of the given mod.
+ */
+export function getInstalledDependsOn(mod: ModData, allMods: ModData[]) {
+  const dependsOn = mod.dependsOn
+    .map((id) => allMods.find((m) => m.modinfo_id === id))
+    .filter(Boolean) as ModData[];
+  const installedDependsOn = dependsOn.filter((m) => m.local != null);
+  return installedDependsOn;
+}
+
+/**
+ * Get all mods that are installed and depend on the given mod.
+ */
+export function getInstalledDependedBy(
+  mod: ModData,
+  allMods: ModData[]
+): ModData[] {
+  const dependedBy = mod.dependedBy
+    .map((id) => allMods.find((m) => m.modinfo_id === id))
+    .filter(Boolean) as ModData[];
+  const installedDependedBy = dependedBy.filter((m) => m.local != null);
+  return installedDependedBy;
+}
+
+/**
+ * Get all the mods needed by the given mod, which are not installed.
+ */
+export function getNotInstalledDependsOn(
+  mod: ModData,
+  allMods: ModData[]
+): ModData[] {
+  const dependsOn = mod.dependsOn
+    .map((id) => allMods.find((m) => m.modinfo_id === id))
+    .filter(Boolean) as ModData[];
+  const notInstalledDependsOn = dependsOn.filter((m) => m.local == null);
+  return notInstalledDependsOn;
+}

--- a/apps/desktop/src/mods/dependencies/getModDependencies.ts
+++ b/apps/desktop/src/mods/dependencies/getModDependencies.ts
@@ -1,0 +1,72 @@
+import { ModData, ModDependency } from '../../home/IModInfo';
+
+type DependencyInfo = {
+  id: string;
+  modData?: ModData;
+  isPresent: boolean;
+  isInstalled: boolean;
+};
+
+function getModInfoId(mod: ModData): string | undefined {
+  return mod.fetched?.expand?.mod_versions_via_mod_id?.[0].modinfo_id;
+}
+
+function createModDataMap(mods: ModData[]): Map<string, ModData> {
+  return new Map(
+    mods
+      .filter((mod) => getModInfoId(mod) != null)
+      .map((mod) => [getModInfoId(mod) as string, mod])
+  );
+}
+
+function getModDependenciesRecursive(
+  mod: ModData,
+  allModsMap: Map<string, ModData>,
+  visited: Set<string>,
+  result: DependencyInfo[]
+) {
+  if (visited.has(mod.id)) return;
+  visited.add(mod.id);
+
+  const latestVersion = mod.fetched?.expand?.mod_versions_via_mod_id?.[0];
+
+  const dependencies = latestVersion?.dependencies as
+    | ModDependency[]
+    | undefined;
+
+  if (!dependencies || dependencies.length === 0) return;
+
+  for (const dependency of dependencies) {
+    if (visited.has(dependency.id)) continue;
+
+    const depMod = allModsMap.get(dependency.id);
+    const isPresent = !!depMod;
+    const isInstalled = !!depMod?.installedVersion;
+
+    result.push({
+      id: dependency.id,
+      modData: depMod,
+      isPresent,
+      isInstalled,
+    });
+
+    if (depMod) {
+      getModDependenciesRecursive(depMod, allModsMap, visited, result);
+    }
+  }
+}
+
+export function getModDependencies(
+  desiredMods: ModData[],
+  allMods: ModData[]
+): DependencyInfo[] {
+  const allModsMap = createModDataMap(allMods);
+  const result: DependencyInfo[] = [];
+  const visited = new Set<string>();
+
+  for (const mod of desiredMods) {
+    getModDependenciesRecursive(mod, allModsMap, visited, result);
+  }
+
+  return result;
+}

--- a/apps/desktop/src/mods/dependencies/getModDependencies.ts
+++ b/apps/desktop/src/mods/dependencies/getModDependencies.ts
@@ -1,14 +1,8 @@
 import { ModData, ModDependency } from '../../home/IModInfo';
-
-type DependencyInfo = {
-  id: string;
-  modData?: ModData;
-  isPresent: boolean;
-  isInstalled: boolean;
-};
+import { DependencyInfo } from './DependencyInfo';
 
 function getModInfoId(mod: ModData): string | undefined {
-  return mod.fetched?.expand?.mod_versions_via_mod_id?.[0].modinfo_id;
+  return mod.modinfo_id;
 }
 
 function createModDataMap(mods: ModData[]): Map<string, ModData> {
@@ -19,53 +13,80 @@ function createModDataMap(mods: ModData[]): Map<string, ModData> {
   );
 }
 
-function getModDependenciesRecursive(
-  mod: ModData,
-  allModsMap: Map<string, ModData>,
-  visited: Set<string>,
-  result: DependencyInfo[]
-) {
-  if (visited.has(mod.id)) return;
-  visited.add(mod.id);
-
-  const latestVersion = mod.fetched?.expand?.mod_versions_via_mod_id?.[0];
-
-  const dependencies = latestVersion?.dependencies as
-    | ModDependency[]
-    | undefined;
-
-  if (!dependencies || dependencies.length === 0) return;
-
-  for (const dependency of dependencies) {
-    if (visited.has(dependency.id)) continue;
-
-    const depMod = allModsMap.get(dependency.id);
-    const isPresent = !!depMod;
-    const isInstalled = !!depMod?.installedVersion;
-
-    result.push({
-      id: dependency.id,
-      modData: depMod,
-      isPresent,
-      isInstalled,
-    });
-
-    if (depMod) {
-      getModDependenciesRecursive(depMod, allModsMap, visited, result);
-    }
-  }
-}
-
+/**
+ * Get all dependencies of the given mods, excluding the mods themselves.
+ */
 export function getModDependencies(
   desiredMods: ModData[],
   allMods: ModData[]
 ): DependencyInfo[] {
   const allModsMap = createModDataMap(allMods);
+
   const result: DependencyInfo[] = [];
+
+  // Recursion tracker
   const visited = new Set<string>();
 
-  for (const mod of desiredMods) {
-    getModDependenciesRecursive(mod, allModsMap, visited, result);
+  // Make sure the dependencies are tracked _only_ once.
+  // This is important because a mod can have multiple dependencies
+  const added = new Set<string>();
+
+  const desiredModIds = new Set(
+    desiredMods.map(getModInfoId).filter((id): id is string => !!id)
+  );
+
+  // Let's use a queue to process FIFO the dependencies.
+  // We process the dependencies of the mods we want to install first.
+  const queue: ModData[] = [...desiredMods];
+
+  while (queue.length > 0) {
+    const currentMod = queue.shift();
+    if (!currentMod) continue;
+
+    const modinfoId = getModInfoId(currentMod);
+    if (!modinfoId || visited.has(modinfoId)) continue;
+    visited.add(modinfoId);
+
+    const currentVersion =
+      currentMod.fetched?.expand?.mod_versions_via_mod_id?.[0];
+
+    const dependencies = currentVersion?.dependencies as
+      | ModDependency[]
+      | undefined;
+    if (!dependencies) continue;
+
+    for (const dep of dependencies) {
+      if (visited.has(dep.id)) continue;
+
+      const depMod = allModsMap.get(dep.id);
+      const isPresent = depMod?.fetched != null;
+      const isInstalled = depMod?.local != null;
+
+      // We want to install the dependency if:
+      // 1. The dependency is not already in the list of desired mods
+      // 2. The dependency is present in the DB (e.g. not game DLCs)
+      // 3. The dependency is not already installed
+      const shouldInstall =
+        !desiredModIds.has(dep.id) && isPresent && !isInstalled;
+
+      if (!added.has(dep.id)) {
+        result.push({
+          id: dep.id,
+          modData: depMod,
+          isPresent,
+          isInstalled,
+          shouldInstall,
+          targetVersion: depMod?.fetched?.expand?.mod_versions_via_mod_id[0],
+        });
+        added.add(dep.id);
+      }
+
+      // If the dependency is not installed and is present in the DB,
+      // we need to add it to the queue for processing.
+      if (depMod) {
+        queue.push(depMod);
+      }
+    }
   }
 
   return result;

--- a/apps/desktop/src/mods/dependencies/installModDependencies.ts
+++ b/apps/desktop/src/mods/dependencies/installModDependencies.ts
@@ -1,0 +1,7 @@
+import { ModData } from '../../home/IModInfo';
+import { getModDependencies } from './getModDependencies';
+
+export async function installModDependencies(
+  desiredMods: ModData[],
+  allMods: ModData[]
+): Promise<void> {}

--- a/apps/desktop/src/mods/dependencies/installModDependencies.ts
+++ b/apps/desktop/src/mods/dependencies/installModDependencies.ts
@@ -1,7 +1,49 @@
 import { ModData } from '../../home/IModInfo';
+import { installMod } from '../installMod';
+import { DependencyInfo } from './DependencyInfo';
 import { getModDependencies } from './getModDependencies';
 
 export async function installModDependencies(
   desiredMods: ModData[],
   allMods: ModData[]
-): Promise<void> {}
+): Promise<DependencyInfo[]> {
+  const dependencies = getModDependencies(desiredMods, allMods);
+  if (dependencies.length === 0) return []; // No dependencies to install
+
+  console.log('[deps] Installing mod dependencies:', dependencies.map(dep => dep.id)); // prettier-ignore
+
+  let installed: DependencyInfo[] = [];
+  for (const dependency of dependencies) {
+    // Skip if not marked for installation
+    if (!dependency.shouldInstall) {
+      console.log(`[deps] Dependency ${dependency.id} will not be installed (already installed?: ${dependency.isInstalled}, present?: ${dependency.isPresent})`); // prettier-ignore
+      continue;
+    }
+
+    // Skip if mod data is not available or not present in DB
+    const mod = dependency.modData;
+    if (!mod) {
+      console.warn(`[deps] Dependency ${dependency.id} is not present in fetched mods`); // prettier-ignore
+      continue;
+    }
+
+    if (!dependency.targetVersion) {
+      console.warn(`[deps] No target version for dependency ${dependency.id} - cannot install`); // prettier-ignore
+      continue;
+    }
+
+    try {
+      await installMod(mod, dependency.targetVersion);
+      installed.push(dependency);
+    } catch (error) {
+      console.error(
+        `[deps] Failed to install dependency ${dependency.id}`,
+        error
+      );
+      throw error; // Rethrow the error to handle it in the calling function
+    }
+  }
+
+  console.log('[deps] All dependencies installed successfully');
+  return installed;
+}

--- a/apps/desktop/src/mods/dependencies/installModDependencies.ts
+++ b/apps/desktop/src/mods/dependencies/installModDependencies.ts
@@ -1,10 +1,10 @@
 import { ModData } from '../../home/IModInfo';
 import { installMod } from '../installMod';
-import { DependencyInfo } from './DependencyInfo';
+import { DependencyInfo, ModInstallTarget } from './DependencyInfo';
 import { getModDependencies } from './getModDependencies';
 
 export async function installModDependencies(
-  desiredMods: ModData[],
+  desiredMods: ModInstallTarget[],
   allMods: ModData[]
 ): Promise<DependencyInfo[]> {
   const dependencies = getModDependencies(desiredMods, allMods);

--- a/apps/desktop/src/mods/dependencies/notifyAddedDependencies.tsx
+++ b/apps/desktop/src/mods/dependencies/notifyAddedDependencies.tsx
@@ -9,12 +9,9 @@ export function notifyAddedDependencies(dependencies: DependencyInfo[]) {
     notifications.show({
       color: 'blue',
       title: 'Dependency installed',
-      message: (
-        <Group>
-          <ModIcon mod={dep.modData} width={24} />
-          {dep.modData!.name} {dep.targetVersion!.name} installed successfully
-        </Group>
-      ),
+      message: `${dep.modData!.name} ${
+        dep.targetVersion!.name
+      } installed successfully`,
     });
     if (i > 3) {
       notifications.show({

--- a/apps/desktop/src/mods/dependencies/notifyAddedDependencies.tsx
+++ b/apps/desktop/src/mods/dependencies/notifyAddedDependencies.tsx
@@ -1,0 +1,28 @@
+import { notifications } from '@mantine/notifications';
+import { DependencyInfo } from './DependencyInfo';
+import { ModIcon } from '../components/ModIcon';
+import { Group } from '@mantine/core';
+
+export function notifyAddedDependencies(dependencies: DependencyInfo[]) {
+  for (let i = 0; i < dependencies.length; i++) {
+    const dep = dependencies[i];
+    notifications.show({
+      color: 'blue',
+      title: 'Dependency installed',
+      message: (
+        <Group>
+          <ModIcon mod={dep.modData} width={24} />
+          {dep.modData!.name} {dep.targetVersion!.name} installed successfully
+        </Group>
+      ),
+    });
+    if (i > 3) {
+      notifications.show({
+        color: 'blue',
+        title: 'More dependencies installed',
+        message: `${dependencies.length - i} more dependencies installed`,
+      });
+      break;
+    }
+  }
+}

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -6,6 +6,7 @@ const host = process.env.TAURI_DEV_HOST;
 // https://vitejs.dev/config/
 export default defineConfig(async () => ({
   plugins: [react()],
+  envDir: '../..',
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
   //

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
     },
     "apps/desktop": {
       "name": "@civmods/desktop",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "dependencies": {
         "@civmods/parser": "*",
         "@mantine/core": "^7.17.1",

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -1,2 +1,3 @@
 export * from './profileCodes';
 export * from './pocketbase-types';
+export * from './headers';

--- a/packages/parser/src/pocketbase-types.ts
+++ b/packages/parser/src/pocketbase-types.ts
@@ -12,6 +12,7 @@ export enum Collections {
 	Otps = "_otps",
 	Superusers = "_superusers",
 	ModVersions = "mod_versions",
+	ModVersionsMetadata = "mod_versions_metadata",
 	Mods = "mods",
 	ScheduledTasks = "scheduled_tasks",
 	Users = "users",
@@ -88,15 +89,15 @@ export type SuperusersRecord = {
 	verified?: boolean
 }
 
-export type ModVersionsRecord = {
+export type ModVersionsRecord<Tdependencies = unknown> = {
 	affect_saves?: boolean
 	archive_hash?: string
 	archive_size?: number
 	cf_id?: string
 	created?: IsoDateString
+	dependencies?: null | Tdependencies
 	download_error?: boolean
 	download_url?: string
-	hash?: string
 	hash_stable?: string
 	id: string
 	is_external_download?: boolean
@@ -110,6 +111,15 @@ export type ModVersionsRecord = {
 	released?: IsoDateString
 	skip_install?: boolean
 	updated?: IsoDateString
+}
+
+export type ModVersionsMetadataRecord<Tcontent = unknown> = {
+	archive_file?: string
+	content?: null | Tcontent
+	created?: IsoDateString
+	id: string
+	updated?: IsoDateString
+	version_id: RecordIdString
 }
 
 export type ModsRecord = {
@@ -160,7 +170,8 @@ export type ExternalauthsResponse<Texpand = unknown> = Required<ExternalauthsRec
 export type MfasResponse<Texpand = unknown> = Required<MfasRecord> & BaseSystemFields<Texpand>
 export type OtpsResponse<Texpand = unknown> = Required<OtpsRecord> & BaseSystemFields<Texpand>
 export type SuperusersResponse<Texpand = unknown> = Required<SuperusersRecord> & AuthSystemFields<Texpand>
-export type ModVersionsResponse<Texpand = unknown> = Required<ModVersionsRecord> & BaseSystemFields<Texpand>
+export type ModVersionsResponse<Tdependencies = unknown, Texpand = unknown> = Required<ModVersionsRecord<Tdependencies>> & BaseSystemFields<Texpand>
+export type ModVersionsMetadataResponse<Tcontent = unknown, Texpand = unknown> = Required<ModVersionsMetadataRecord<Tcontent>> & BaseSystemFields<Texpand>
 export type ModsResponse<Texpand = unknown> = Required<ModsRecord> & BaseSystemFields<Texpand>
 export type ScheduledTasksResponse<Toptions = unknown, Texpand = unknown> = Required<ScheduledTasksRecord<Toptions>> & BaseSystemFields<Texpand>
 export type UsersResponse<Texpand = unknown> = Required<UsersRecord> & AuthSystemFields<Texpand>
@@ -174,6 +185,7 @@ export type CollectionRecords = {
 	_otps: OtpsRecord
 	_superusers: SuperusersRecord
 	mod_versions: ModVersionsRecord
+	mod_versions_metadata: ModVersionsMetadataRecord
 	mods: ModsRecord
 	scheduled_tasks: ScheduledTasksRecord
 	users: UsersRecord
@@ -186,6 +198,7 @@ export type CollectionResponses = {
 	_otps: OtpsResponse
 	_superusers: SuperusersResponse
 	mod_versions: ModVersionsResponse
+	mod_versions_metadata: ModVersionsMetadataResponse
 	mods: ModsResponse
 	scheduled_tasks: ScheduledTasksResponse
 	users: UsersResponse
@@ -201,6 +214,7 @@ export type TypedPocketBase = PocketBase & {
 	collection(idOrName: '_otps'): RecordService<OtpsResponse>
 	collection(idOrName: '_superusers'): RecordService<SuperusersResponse>
 	collection(idOrName: 'mod_versions'): RecordService<ModVersionsResponse>
+	collection(idOrName: 'mod_versions_metadata'): RecordService<ModVersionsMetadataResponse>
 	collection(idOrName: 'mods'): RecordService<ModsResponse>
 	collection(idOrName: 'scheduled_tasks'): RecordService<ScheduledTasksResponse>
 	collection(idOrName: 'users'): RecordService<UsersResponse>


### PR DESCRIPTION
- Support for Mods dependencies (for now only mod->mod dependencies, no DLCs)
- Refactor to allow for `.tgz` files
- Mods metadata extraction, in order to save metadata for further processing
- Mods cache to avoid gateway errors during CF downtime