### PR TITLE
Fix "Failed to parse filename or extension" on downloads/updates

### DIFF
--- a/apps/desktop/src/mods/installMod.ts
+++ b/apps/desktop/src/mods/installMod.ts
@@ -129,7 +129,7 @@ async function downloadCachedVersion(
     .collection('mod_versions_metadata')
     .getList(1, 1, {
       filter: pb.filter('version_id = {:version_id}', {
-        version_id: version.version_parent_id ?? version.id,
+        version_id: version.version_parent_id?.trim() || version.id,
       }),
     })
     .then((res) => res.items?.[0]);
@@ -169,8 +169,19 @@ async function runLowLevelInstallMod(
   console.log('Downloading mod from:', version.download_url);
   let response = await fetch(version.download_url);
 
-  // Fallback to cached version if download fails for 5xx errors
-  if (!response.ok && response.status >= 500) {
+  // CivFanatics may return HTTP 200 with a Stile anti-bot challenge page.
+  // In that case the response is not the mod archive, so use the CivMods cache.
+  const isCivFanaticsStileChallenge =
+    response.url.includes('/.stile/challenge');
+
+  if (
+    (!response.ok && response.status >= 500) ||
+    isCivFanaticsStileChallenge
+  ) {
+    console.log(
+      'CivFanatics Stile challenge detected; using cached mod version.'
+    );
+
     response = await downloadCachedVersion(
       `Failed to download mod: ${response.statusText}`,
       version


### PR DESCRIPTION
## Summary

Fixes the `Failed to parse filename or extension` error that prevents CivMods from installing mods downloaded from CivFanatics when CivFanatics returns a Stile anti-bot challenge.

### Problem

CivFanatics can return HTTP 200 while redirecting the requested mod download to:

`/.stile/challenge`

CivMods therefore treats the response as a successful download, but the response is actually the Stile challenge page rather than the mod archive. The subsequent installation process cannot determine the archive filename/extension and fails with:

`Failed to parse filename or extension`

This makes affected CivFanatics mods impossible to install through CivMods.

### Fix

This PR:

1. Detects a CivFanatics `/.stile/challenge` redirect even when the HTTP response status is 200, and falls back to the CivMods cached archive instead of attempting to process the challenge page as a mod archive.
2. Treats an empty or whitespace-only `version_parent_id` as missing when looking up cached metadata, correctly falling back to the current `version.id`.

The second fix is required because some cached versions have an empty `version_parent_id`, which otherwise prevents CivMods from finding the cached archive.

### Validation

The fix was built into a Windows CivMods MSI and tested with four mods that were previously failing.

After applying the fix, all four mods installed successfully through the CivFanatics challenge/cache path, resolving the:

`Failed to parse filename or extension`

installation failure.

The repository currently contains no Vitest test files, so `npx vitest --run` reports that no test files were found.

The PR contains only the two targeted changes to:

`apps/desktop/src/mods/installMod.ts`

No build-only, packaging, or local configuration changes are included.

Submitted by **Aurora ICT - Australia**.